### PR TITLE
fix: send timestamp with 'Z' timezone

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -76,7 +76,7 @@ export default class ActivityWatchPlugin extends Plugin {
 
 	async sendHeartbeatData(id: string, heartbeat_data: object, pulsetime: number) {
 		const endpoint = `buckets/${id}/heartbeat?pulsetime=${pulsetime}`
-		const t = new Date().toISOString().slice(0, -1) + "000+00:00"  // there is probably better ways, but this is required for rust server to work
+		const t = new Date().toISOString()
 		await this.post(endpoint, {"timestamp": t, "duration": 0, "data": heartbeat_data})
 	}
 


### PR DESCRIPTION
Doesn't actually change the behavior, but shows the "right way" to do it :)

As per discussion in Discord: https://discord.com/channels/755040852727955476/755334543891759194/1068924076317491200